### PR TITLE
build(default): add stylelint config

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15029,6 +15029,12 @@
         }
       }
     },
+    "stylelint-config-recommended": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
+      "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
+      "dev": true
+    },
     "stylus": {
       "version": "0.54.8",
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.8.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -52,6 +52,7 @@
     "postcss-scss": "^3.0.2",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.0.2",
+    "stylelint-config-recommended": "^3.0.0",
     "tailwindcss": "^1.8.10",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",

--- a/client/stylelint.config.js
+++ b/client/stylelint.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  extends: ['stylelint-config-recommended'],
+  rules: {
+    'at-rule-no-unknown': [
+      true,
+      {
+        ignoreAtRules: ['tailwind', 'apply', 'variants', 'responsive', 'screen'],
+      },
+    ],
+    'declaration-block-trailing-semicolon': null,
+    'no-descending-specificity': null,
+  },
+};


### PR DESCRIPTION
Add stylelint to prevent vsc from complaining about tailwind directives inside scss files. Add stylelint-config-recommended dev dependency for style linting best practices.